### PR TITLE
Fix tooltip property mispelling in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -100,7 +100,7 @@
               <p>&nbsp;&nbsp;&nbsp;&nbsp;}]</p>
               <p>&nbsp;&nbsp;},</p>
               <p>&nbsp;&nbsp;options: {</p>
-              <p>&nbsp;&nbsp;&nbsp;&nbsp;tooplips: {</p>
+              <p>&nbsp;&nbsp;&nbsp;&nbsp;tooltips: {</p>
               <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bevelWidth: 3,</p>
               <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bevelHighlightColor: 'rgba(255, 255, 255, 0.75)',</p>
               <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bevelShadowColor: 'rgba(0, 0, 0, 0.5)'</p>
@@ -133,7 +133,7 @@
               <p>&nbsp;&nbsp;&nbsp;&nbsp;}]</p>
               <p>&nbsp;&nbsp;},</p>
               <p>&nbsp;&nbsp;options: {</p>
-              <p>&nbsp;&nbsp;&nbsp;&nbsp;tooplips: {</p>
+              <p>&nbsp;&nbsp;&nbsp;&nbsp;tooltips: {</p>
               <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;...</p>
               <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shadowOffsetX: 3,</p>
               <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shadowOffsetY: 3,</p>


### PR DESCRIPTION
Fix some misspellings in documentation examples:

<img width="474" alt="chartjs-plugin-style 2020-09-21 13-42-48" src="https://user-images.githubusercontent.com/3279/93819299-686ef580-fc10-11ea-9d30-852c01297d89.png">
